### PR TITLE
Small cleanup in Format Model and TextDecorationCollection initializa…

### DIFF
--- a/Notepad2/Notepad/FormatModel.cs
+++ b/Notepad2/Notepad/FormatModel.cs
@@ -9,18 +9,18 @@ namespace Notepad2.Notepad
         private FontStyle _style;
         public FontStyle Style
         {
-            get { return _style; }
-            set { RaisePropertyChanged(ref _style, value); }
+            get => _style;
+            set => RaisePropertyChanged(ref _style, value);
         }
 
         private FontWeight _weight;
         public FontWeight Weight
         {
-            get { return _weight; }
-            set { RaisePropertyChanged(ref _weight, value); }
+            get => _weight;
+            set => RaisePropertyChanged(ref _weight, value);
         }
 
-        private TextDecorationCollection _decoration;
+        private TextDecorationCollection _decoration = new TextDecorationCollection();
         public TextDecorationCollection Decoration
         {
             get => _decoration;
@@ -30,24 +30,21 @@ namespace Notepad2.Notepad
         private FontFamily _family;
         public FontFamily Family
         {
-            get { return _family; }
-            set { RaisePropertyChanged(ref _family, value); }
+            get => _family;
+            set => RaisePropertyChanged(ref _family, value);
         }
 
         private TextWrapping _wrap;
         public TextWrapping Wrap
         {
-            get { return _wrap; }
-            set
-            {
-                RaisePropertyChanged(ref _wrap, value);
-            }
+            get => _wrap;
+            set => RaisePropertyChanged(ref _wrap, value);
         }
 
         private bool _isWrapped;
         public bool IsWrapped
         {
-            get { return _isWrapped; }
+            get => _isWrapped;
             set
             {
                 RaisePropertyChanged(ref _isWrapped, value);
@@ -58,8 +55,8 @@ namespace Notepad2.Notepad
         private double _size;
         public double Size
         {
-            get { return _size; }
-            set { RaisePropertyChanged(ref _size, value); }
+            get => _size;
+            set => RaisePropertyChanged(ref _size, value);
         }
     }
 }


### PR DESCRIPTION
Hello! :-)
Do you mind if i try to join developing?
I've noticed small bug - when created new file - combobox with text decoration options is empty by default, but i guess it should have value "None" instead.
I've fixed this and cleaned a bit code in FormatModel class.

![change1](https://user-images.githubusercontent.com/30569140/82705399-43796e80-9c80-11ea-9a30-a36cea6651c8.png)